### PR TITLE
Allow shortcode category filtering by slug.

### DIFF
--- a/classes/SimpleLinksFactory.php
+++ b/classes/SimpleLinksFactory.php
@@ -129,7 +129,11 @@ class SimpleLinksFactory {
 				if( is_numeric( $cat ) ){
 					$cat = get_term_by( 'id', $cat, Simple_Links_Categories::TAXONOMY );
 				} else {
-					$cat = get_term_by( 'name', $cat, Simple_Links_Categories::TAXONOMY );
+					if ( !empty( get_term_by( 'name', $cat, Simple_Links_Categories::TAXONOMY ) ) ) {
+						$cat = get_term_by( 'name', $cat, Simple_Links_Categories::TAXONOMY );
+					} else {
+						$cat = get_term_by( 'slug', $cat, Simple_Links_Categories::TAXONOMY );
+					}
 				}
 				if( ! empty( $cat->term_id ) ){
 					$all_cats[] = $cat->term_id;


### PR DESCRIPTION
Added a simple conditional that will allow you to filter links by category slug, as well as ID and name. This is especially helpful for categories with an ampersand in the title.