### PR TITLE
Update simple_links_admin.php

### DIFF
--- a/classes/simple_links_admin.php
+++ b/classes/simple_links_admin.php
@@ -418,7 +418,7 @@ class simple_links_admin {
 
 					//The element to point to
 					$('#menu-posts-simple_link').pointer({
-						content: ' <?php echo esc_js( $pointer_content ); ?>',
+						content: ' <?php echo $pointer_content; ?>',
 						position: {
 							edge: 'left',
 							align: 'center'


### PR DESCRIPTION
esc_js() causes the HTML styling to be escaped; since there's no JS in the string, I don't think esc_js is necessary, and escaping causes the styling (`<h3>`/`<p>`) to break